### PR TITLE
Add compatibility with latest jQuery v3.1*

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -453,7 +453,7 @@
                             $this.auto();
                         }   
                     }else{
-                        obj.find('img').load(function () {
+                        obj.find('img').on('load', function () {
                             setTimeout(function () {
                                 setCss();
                                 if (!interval) {


### PR DESCRIPTION
Since jQuery 3 `.load` event listener has been deprecated. 
`on('load', cb)` must be used
More details: [https://blog.jquery.com/](https://blog.jquery.com/)
